### PR TITLE
Tls processing - modifiable length

### DIFF
--- a/src/talos/enclaveshim/logpoint.c
+++ b/src/talos/enclaveshim/logpoint.c
@@ -14,6 +14,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 
 #include "openssl/ossl_typ.h"
 #include "tls_processing_interface.h"
@@ -21,7 +22,7 @@
 #include "enclaveshim_config.h"
 
 // define this macro to activate this module
-#undef DO_LOGGING
+#define DO_LOGGING
 
 // define this macro if you are using this module with Squid
 #undef LOG_FOR_SQUID
@@ -73,9 +74,8 @@ void log_https_request(const SSL* s, char* req, int* len) {
 		return; // Squid, this is not a message between the client and the proxy, so don't log
 	}
 #endif
-	my_printf("%s SSL %p, there is a request of %d bytes\n", __func__, s, len*);
+	my_printf("%s SSL %p, there is a request of %d bytes\n", __func__, s, *len);
 }
-
 void log_https_reply(const SSL* s, char* rep, int* len) {
 #ifdef LOG_FOR_SQUID
 	long type;
@@ -87,7 +87,7 @@ void log_https_reply(const SSL* s, char* rep, int* len) {
 		return; // Squid, this is not a message between the client and the proxy, so don't log
 	}
 #endif
-	my_printf("%s SSL %p, there is a reply of %d bytes\n", __func__, s, len*);
+	my_printf("%s SSL %p, there is a reply of %d bytes\n", __func__, s, *len);
 }
 
 void log_set_ssl_type(const void* b, const long type) {

--- a/src/talos/enclaveshim/logpoint.c
+++ b/src/talos/enclaveshim/logpoint.c
@@ -2,10 +2,10 @@
  * Copyright 2017 Imperial College London
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at   
- * 
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
@@ -62,7 +62,7 @@ static thread_mutex_t bio2type_mutex = THREAD_MUTEX_INITIALIZER;
 
 #ifdef DO_LOGGING
 
-void log_https_request(const SSL* s, char* req, unsigned int len) {
+void log_https_request(const SSL* s, char* req, int* len) {
 #ifdef LOG_FOR_SQUID
 	long type;
 	pthread_mutex_lock(&bio2type_mutex);
@@ -73,10 +73,10 @@ void log_https_request(const SSL* s, char* req, unsigned int len) {
 		return; // Squid, this is not a message between the client and the proxy, so don't log
 	}
 #endif
-	my_printf("%s SSL %p, there is a request of %d bytes\n", __func__, s, len);
+	my_printf("%s SSL %p, there is a request of %d bytes\n", __func__, s, len*);
 }
 
-void log_https_reply(const SSL* s, char* rep, unsigned int len) {
+void log_https_reply(const SSL* s, char* rep, int* len) {
 #ifdef LOG_FOR_SQUID
 	long type;
 	pthread_mutex_lock(&bio2type_mutex);
@@ -87,7 +87,7 @@ void log_https_reply(const SSL* s, char* rep, unsigned int len) {
 		return; // Squid, this is not a message between the client and the proxy, so don't log
 	}
 #endif
-	my_printf("%s SSL %p, there is a reply of %d bytes\n", __func__, s, len);
+	my_printf("%s SSL %p, there is a reply of %d bytes\n", __func__, s, len*);
 }
 
 void log_set_ssl_type(const void* b, const long type) {
@@ -133,4 +133,3 @@ void tls_processing_module_init() {
 	tls_processing_register_free_connection_cb(log_free_connection);
 #endif
 }
-

--- a/src/talos/enclaveshim/logpoint.c
+++ b/src/talos/enclaveshim/logpoint.c
@@ -22,7 +22,7 @@
 #include "enclaveshim_config.h"
 
 // define this macro to activate this module
-#define DO_LOGGING
+#undef DO_LOGGING
 
 // define this macro if you are using this module with Squid
 #undef LOG_FOR_SQUID

--- a/src/talos/enclaveshim/tls_processing_interface.c
+++ b/src/talos/enclaveshim/tls_processing_interface.c
@@ -2,10 +2,10 @@
  * Copyright 2017 Imperial College London
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at   
- * 
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
@@ -26,17 +26,17 @@
 // this function must be defined by your TLS processing module
 extern void tls_processing_module_init(void);
 
-static void (*ssl_read_processing_cb)(const SSL*, char*, unsigned int) = NULL;
-static void (*ssl_write_processing_cb)(const SSL*, char*, unsigned int) = NULL;
+static void (*ssl_read_processing_cb)(const SSL*, char*, int*) = NULL;
+static void (*ssl_write_processing_cb)(const SSL*, char*, int*) = NULL;
 static void (*set_ssl_type_cb)(const void*, const long) = NULL;
 static void (*new_connection_cb)(const SSL*) = NULL;
 static void (*free_connection_cb)(const SSL*) = NULL;
 
-void tls_processing_register_ssl_read_processing_cb(void (*cb)(const SSL*, char*, unsigned int)) {
+void tls_processing_register_ssl_read_processing_cb(void (*cb)(const SSL*, char*, int*)) {
 	ssl_read_processing_cb = cb;
 }
 
-void tls_processing_register_ssl_write_processing_cb(void (*cb)(const SSL*, char*, unsigned int)) {
+void tls_processing_register_ssl_write_processing_cb(void (*cb)(const SSL*, char*, int*)) {
 	ssl_write_processing_cb = cb;
 }
 
@@ -62,12 +62,12 @@ void ecall_tls_processing_module_init(void) {
 }
 
 // called by ssl3_read_bytes() in ssl/s3_pkt.c when data is read from the TLS connection socket
-void tls_processing_ssl_read(const SSL* s, char* data, unsigned int len) {
+void tls_processing_ssl_read(const SSL* s, char* data, int* len) {
 	CHECK_AND_CALL_CB(ssl_read_processing_cb, s, data, len);
 }
 
 // called by do_ssl3_write() in ssl/s3_pkt.c when data is read from the TLS connection socket
-void tls_processing_ssl_write(const SSL* s, char* data, unsigned int len) {
+void tls_processing_ssl_write(const SSL* s, char* data, int* len) {
 	CHECK_AND_CALL_CB(ssl_write_processing_cb, s, data, len);
 }
 
@@ -85,4 +85,3 @@ void tls_processing_new_connection(const SSL* s) {
 void tls_processing_free_connection(const SSL* s) {
 	CHECK_AND_CALL_CB(free_connection_cb, s);
 }
-

--- a/src/talos/enclaveshim/tls_processing_interface.h
+++ b/src/talos/enclaveshim/tls_processing_interface.h
@@ -2,10 +2,10 @@
  * Copyright 2017 Imperial College London
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at   
- * 
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
@@ -20,8 +20,8 @@
 
 /***** public function: you need to use them to register your callbacks *****/
 
-void tls_processing_register_ssl_read_processing_cb(void (*cb)(const SSL*, char*, unsigned int));
-void tls_processing_register_ssl_write_processing_cb(void (*cb)(const SSL*, char*, unsigned int));
+void tls_processing_register_ssl_read_processing_cb(void (*cb)(const SSL*, char*, int*));
+void tls_processing_register_ssl_write_processing_cb(void (*cb)(const SSL*, char*, int*));
 void tls_processing_register_set_ssl_type_cb(void (*cb)(const void*, const long));
 void tls_processing_register_new_connection_cb(void (*cb)(const SSL*));
 void tls_processing_register_free_connection_cb(void (*cb)(const SSL*));
@@ -34,10 +34,10 @@ void tls_processing_register_free_connection_cb(void (*cb)(const SSL*));
 void ecall_tls_processing_module_init(void);
 
 // called by ssl3_read_bytes() in ssl/s3_pkt.c when data is read from the TLS connection socket
-void tls_processing_ssl_read(const SSL* s, char* data, unsigned int len);
+void tls_processing_ssl_read(const SSL* s, char* data, int* len);
 
 // called by do_ssl3_write() in ssl/s3_pkt.c when data is read from the TLS connection socket
-void tls_processing_ssl_write(const SSL* s, char* data, unsigned int len);
+void tls_processing_ssl_write(const SSL* s, char* data, int* len);
 
 // called by BIO_int_ctrl when the command is BIO_C_SET_FD. Originally used for Squid in SSL proxy mode
 void tls_processing_set_ssl_type(const void* b, const long type);

--- a/src/talos/patch/s3_pkt.c.patch
+++ b/src/talos/patch/s3_pkt.c.patch
@@ -3,15 +3,15 @@
 @@ -117,8 +117,15 @@
  #include <openssl/buffer.h>
  #include <openssl/evp.h>
- 
+
 +#ifdef COMPILE_WITH_INTEL_SGX
 +#include "sgx_trts.h"
 +#endif
 +
  #include "bytestring.h"
- 
-+extern void tls_processing_ssl_read(const SSL* s, char* data, unsigned int len);
-+extern void tls_processing_ssl_write(const SSL* s, char* data, unsigned int len);
+
++extern void tls_processing_ssl_read(const SSL* s, char* data, int* len);
++extern void tls_processing_ssl_write(const SSL* s, char* data, int* len);
 +
  static int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
      unsigned int len, int create_empty_fragment);
@@ -19,16 +19,16 @@
 @@ -705,6 +712,19 @@
  	memcpy(wr->data, wr->input, wr->length);
  	wr->input = wr->data;
- 
+
 +	//LOGGING: log wr->data of size wr->length. wr->data contains part
-+	// of the HTTPS response in clear before encryption. There may be 
++	// of the HTTPS response in clear before encryption. There may be
 +	// multiple calls to do_ssl3_write() for a single HTTPS response.
 +	// for the HTTPS response buf is not within the enclave. It is copied just before
 +	// this comment to wr->data. buf also contains the reply headers
 +#ifdef COMPILE_WITH_INTEL_SGX
 +	if (!sgx_is_within_enclave(buf, sizeof(*buf))) {
 +#endif
-+		tls_processing_ssl_write((const SSL*)s, (char*)wr->data, (unsigned int)wr->length);
++		tls_processing_ssl_write((const SSL*)s, (char*)wr->data, &(wr->length));
 +#ifdef COMPILE_WITH_INTEL_SGX
 +	}
 +#endif
@@ -39,7 +39,7 @@
 @@ -954,6 +974,18 @@
  		else
  			n = (unsigned int)len;
- 
+
 +		//LOGGING: log rr->data of size rr->length. rr->data contains part
 +		// of the HTTPS request in clear after decryption.
 +		// There is only one call to ssl3_read-bytes for a single HTTPS request.
@@ -47,7 +47,7 @@
 +#ifdef COMPILE_WITH_INTEL_SGX
 +		if (!sgx_is_within_enclave(buf, sizeof(*buf))) {
 +#endif
-+			tls_processing_ssl_read((const SSL*)s, (char*)(rr->data+rr->off), (unsigned int)n);
++			tls_processing_ssl_read((const SSL*)s, (char*)(rr->data+rr->off), &n);
 +#ifdef COMPILE_WITH_INTEL_SGX
 +		}
 +#endif


### PR DESCRIPTION
Little change to the tls-processing functions. 
Changing `unsigned int` into `int*` allows to change not only contents of the packet message but also it's length.
Nice example of the usefulness: We have requests from the user over tls with sensitive data (passwords, tokens etc.) so now we can edit the request so that the forwarded message (e.g. from nginx to HTTP server) will not contain any sensitive data.
We can also think about verification of data via passing it encrypted to other sgx enclave (e.g. Database query). 
