### PR TITLE
Fix compilation

### DIFF
--- a/src/libressl-2.4.1/crypto/Makefile.sgx
+++ b/src/libressl-2.4.1/crypto/Makefile.sgx
@@ -1,0 +1,861 @@
+#Copyright 2017 Imperial College London
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+top_srcdir=..
+CC=gcc
+CCASFLAGS=-g -O2 -Wall -Werror -std=gnu99 -fno-strict-aliasing -fno-strict-overflow -D_FORTIFY_SOURCE=2 -fstack-protector-all -DHAVE_GNU_STACK -Wno-implicit-function-declaration
+CFLAGS=-g -O2 -Wall -Werror -std=gnu99 -fno-strict-aliasing -fno-strict-overflow -D_FORTIFY_SOURCE=2 -fstack-protector-all -DHAVE_GNU_STACK -Wno-pointer-sign
+CPPFLAGS=-DLIBRESSL_INTERNAL -DOPENSSL_NO_HW_PADLOCK -DOPENSSLDIR=\"/etc/ssl\" -DAES_ASM -DBSAES_ASM -DVPAES_ASM -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DMD5_ASM -DGHASH_ASM -DRSA_ASM -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DWHIRLPOOL_ASM -DOPENSSL_CPUID_OBJ -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_SOURCE -D_GNU_SOURCE -DNO_SYSLOG -DOPENSSL_NO_TLSEXT -DCOMPILE_WITH_INTEL_SGX -DSQLITE_OMIT_LOAD_EXTENSION -DSQLITE_THREADSAFE=0
+#DEFS=-DPACKAGE_NAME=\"libressl\" -DPACKAGE_TARNAME=\"libressl\" -DPACKAGE_VERSION=\"2.4.1\" -DPACKAGE_STRING=\"libressl2.4.1\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"libressl\" -DVERSION=\"2.4.1\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_SYMLINK=1 -DHAVE_ERR_H=1 -DHAVE_ASPRINTF=1 -DHAVE_INET_PTON=1 -DHAVE_MEMMEM=1 -DHAVE_STRNDUP=1 -DHAVE_STRNLEN=1 -DHAVE_STRSEP=1 -DHAVE_TIMEGM=1 -DHAVE_ACCEPT4=1 -DHAVE_POLL=1 -DHAVE_GETAUXVAL=1 -DHAVE_VA_COPY=1 -DHAVE___VA_COPY=1 -DHAS_GNU_WARNING_LONG=1 -DSIZEOF_TIME_T=8
+DEFS=-DPACKAGE_NAME=\"libressl\" -DPACKAGE_TARNAME=\"libressl\" -DPACKAGE_VERSION=\"2.4.1\" -DPACKAGE_STRING=\"libressl2.4.1\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"libressl\" -DVERSION=\"2.4.1\" -DSTDC_HEADERS=0 -DHAVE_SYS_TYPES_H=0 -DHAVE_SYS_STAT_H=0 -DHAVE_STDLIB_H=0 -DHAVE_STRING_H=0 -DHAVE_MEMORY_H=0 -DHAVE_STRINGS_H=0 -DHAVE_INTTYPES_H=0 -DHAVE_STDINT_H=0 -DHAVE_UNISTD_H=0 -DHAVE_DLFCN_H=0 -DLT_OBJDIR=\".libs/\" -DHAVE_SYMLINK=0 -DHAVE_ERR_H=0 -DHAVE_ASPRINTF=0 -DHAVE_INET_PTON=0 -DHAVE_MEMMEM=0 -DHAVE_STRNDUP=0 -DHAVE_STRNLEN=0 -DHAVE_STRSEP=0 -DHAVE_TIMEGM=0 -DHAVE_ACCEPT4=0 -DHAVE_POLL=0 -DHAVE_GETAUXVAL=0 -DHAVE_VA_COPY=0 -DHAVE___VA_COPY=0 -DHAS_GNU_WARNING_LONG=1 -DSIZEOF_TIME_T=8
+INCLUDE=-I. -I${top_srcdir}/include -I${top_srcdir}/include/compat -I${top_srcdir}/crypto/asn1 -I${top_srcdir}/crypto/evp -I${top_srcdir}/crypto/modes -I${top_srcdir}/crypto -I${top_srcdir}/include/openssl
+LDFLAGS=-Wl,-z,relro -Wl,-z,now
+
+
+########## Intel SGX ############
+
+##### Parameters #####
+
+SGX_SDK ?= /opt/intel/sgxsdk
+SGX_MODE ?= SIM
+SGX_COMMON_CFLAGS := -m64
+SGX_LIBRARY_PATH := $(SGX_SDK)/lib64
+SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x64/sgx_sign
+SGX_EDGER8R := $(SGX_SDK)/bin/x64/sgx_edger8r
+
+SGX_COMMON_CFLAGS += -g -O2
+
+ifeq ($(SGX_MODE), HW)
+	Urts_Library_Name := sgx_urts
+	Trts_Library_Name := sgx_trts
+	Service_Library_Name := sgx_tservice
+else
+	Urts_Library_Name := sgx_urts_sim
+	Trts_Library_Name := sgx_trts_sim
+	Service_Library_Name := sgx_tservice_sim
+endif
+Crypto_Library_Name := sgx_tcrypto
+
+Enclave_Name := enclave.so
+Signed_Enclave_Name := enclave.signed.so
+
+Enclave_Config_File := enclave.config.xml
+
+App_Link_Flags := $(SGX_COMMON_CFLAGS) -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name)
+
+ifeq ($(SGX_MODE), HW)
+	App_Link_Flags += -lsgx_uae_service
+else
+	App_Link_Flags += -lsgx_uae_service_sim
+endif
+
+#################################
+
+
+all: link signed_enclave enclave_u.o
+
+
+########## Intel SGX ############
+
+##### App Objects #####
+
+App_C_Flags := $(SGX_COMMON_CFLAGS) -fPIC -Wno-attributes -Wno-implicit-function-declaration
+
+# Three configuration modes - Debug, prerelease, release
+#   Debug - Macro DEBUG enabled.
+#   Prerelease - Macro NDEBUG and EDEBUG enabled.
+#   Release - Macro NDEBUG enabled.
+ifeq ($(SGX_DEBUG), 1)
+	App_C_Flags += -DDEBUG -UNDEBUG -UEDEBUG
+else ifeq ($(SGX_PRERELEASE), 1)
+	App_C_Flags += -DNDEBUG -DEDEBUG -UDEBUG
+else
+	App_C_Flags += -DNDEBUG -UEDEBUG -UDEBUG
+endif
+
+# Hack with SGX SDK >1.9 that makes calls to OpenSSL during
+# enclave creation
+ifeq ($(SGX_MODE), HW)
+	Enclaveshim_SGX_mode := -USGX_MODE_SIM
+else
+	Enclaveshim_SGX_mode := -DSGX_MODE_SIM
+endif
+
+enclave_u.c: $(SGX_EDGER8R) enclave.edl
+	@$(SGX_EDGER8R) --untrusted enclave.edl --search-path . --search-path $(SGX_SDK)/include
+	@echo "GEN  =>  $@"
+
+enclave_u.o: enclave_u.c
+	@$(CC) $(App_C_Flags) -I../include -I$(SGX_SDK)/include -c $< -o $@
+	@echo "CC   <=  $<"
+
+hashmap-nosgx.o: hashmap.c
+	@$(CC) $(App_C_Flags) -UCOMPILE_WITH_INTEL_SGX -c $< -o $@
+	@echo "CC   <=  $<"
+
+ecall_queue-nosgx.o: ecall_queue.c
+	$(CC) $(App_C_Flags) -UCOMPILE_WITH_INTEL_SGX -fPIC -c -o $@ $<
+	@echo "CC   <=  $<"
+
+enclaveshim_ecalls.o: enclaveshim_ecalls.c
+	@$(CC) $(App_C_Flags) $(Enclaveshim_SGX_mode) -I../include -I$(SGX_SDK)/include -c $< -o $@
+	@echo "CC   <=  $<"
+
+ocalls.o: ocalls.c
+	@$(CC) -g -O2 -I../include -fPIC -DPIC -c $< -o $@
+	@echo "CC   <=  $<"
+
+##### Enclave Objects #####
+
+Enclave_Include_Paths := -I. -I../include -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SDK)/include/stlport
+
+Enclave_C_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fstack-protector $(Enclave_Include_Paths)
+Enclave_Cpp_Flags := $(Enclave_C_Flags) -nostdinc -nostdinc++
+Enclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_LIBRARY_PATH) \
+	-Wl,--whole-archive -l$(Trts_Library_Name) -Wl,--no-whole-archive \
+	-Wl,--start-group -lsgx_tstdc -lsgx_tcxx -lsgx_tcmalloc -l$(Crypto_Library_Name) -l$(Service_Library_Name) -Wl,--end-group \
+	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
+	-Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
+	-Wl,--defsym,__ImageBase=0 \
+	-Wl,--version-script=enclave.lds
+
+enclave_t.c: $(SGX_EDGER8R) enclave.edl
+	@$(SGX_EDGER8R) --trusted ./enclave.edl --search-path . --search-path $(SGX_SDK)/include
+	@echo "GEN  =>  $@"
+
+enclave_t.o: enclave_t.c
+	@$(CC) $(Enclave_C_Flags) -DDEFINE_TIME_STRUCT -c $< -o $@
+	@echo "CC   <=  $<"
+
+#################################
+
+
+SFILES = aes/aes-elf-x86_64.o \
+			aes/bsaes-elf-x86_64.o \
+			aes/vpaes-elf-x86_64.o \
+			aes/aesni-elf-x86_64.o \
+			aes/aesni-sha1-elf-x86_64.o \
+			bn/modexp512-elf-x86_64.o \
+			bn/mont-elf-x86_64.o \
+			bn/mont5-elf-x86_64.o \
+			bn/gf2m-elf-x86_64.o \
+			camellia/cmll-elf-x86_64.o \
+			md5/md5-elf-x86_64.o \
+			modes/ghash-elf-x86_64.o \
+			rc4/rc4-elf-x86_64.o \
+			rc4/rc4-md5-elf-x86_64.o \
+			sha/sha1-elf-x86_64.o \
+			whrlpool/wp-elf-x86_64.o \
+
+LIBCRYPTO_SFILES = sha/sha256-elf-x86_64.o \
+			 sha/sha512-elf-x86_64.o \
+			 cpuid-elf-x86_64.o \
+
+LIBCRYPTO_CFILES = cpt_err.o \
+			 cryptlib.o \
+			 cversion.o \
+			 ex_data.o \
+			 malloc-wrapper.o \
+			 mem_clr.o \
+			 mem_dbg.o \
+			 o_init.o \
+			 o_str.o \
+			 o_time.o \
+			 hashmap.o \
+			 aes/aes_cfb.o \
+			 aes/aes_ctr.o \
+			 aes/aes_ecb.o \
+			 aes/aes_ige.o \
+			 aes/aes_misc.o \
+			 aes/aes_ofb.o \
+			 aes/aes_wrap.o \
+			 asn1/a_bitstr.o \
+			 asn1/a_bool.o \
+			 asn1/a_bytes.o \
+			 asn1/a_d2i_fp.o \
+			 asn1/a_digest.o \
+			 asn1/a_dup.o \
+			 asn1/a_enum.o \
+			 asn1/a_i2d_fp.o \
+			 asn1/a_int.o \
+			 asn1/a_mbstr.o \
+			 asn1/a_object.o \
+			 asn1/a_octet.o \
+			 asn1/a_print.o \
+			 asn1/a_set.o \
+			 asn1/a_sign.o \
+			 asn1/a_strex.o \
+			 asn1/a_strnid.o \
+			 asn1/a_time.o \
+			 asn1/a_time_tm.o \
+			 asn1/a_type.o \
+			 asn1/a_utf8.o \
+			 asn1/a_verify.o \
+			 asn1/ameth_lib.o \
+			 asn1/asn1_err.o \
+			 asn1/asn1_gen.o \
+			 asn1/asn1_lib.o \
+			 asn1/asn1_par.o \
+			 asn1/asn_mime.o \
+			 asn1/asn_moid.o \
+			 asn1/asn_pack.o \
+			 asn1/bio_asn1.o \
+			 asn1/bio_ndef.o \
+			 asn1/d2i_pr.o \
+			 asn1/d2i_pu.o \
+			 asn1/evp_asn1.o \
+			 asn1/f_enum.o \
+			 asn1/f_int.o \
+			 asn1/f_string.o \
+			 asn1/i2d_pr.o \
+			 asn1/i2d_pu.o \
+			 asn1/n_pkey.o \
+			 asn1/nsseq.o \
+			 asn1/p5_pbe.o \
+			 asn1/p5_pbev2.o \
+			 asn1/p8_pkey.o \
+			 asn1/t_bitst.o \
+			 asn1/t_crl.o \
+			 asn1/t_pkey.o \
+			 asn1/t_req.o \
+			 asn1/t_spki.o \
+			 asn1/t_x509.o \
+			 asn1/t_x509a.o \
+			 asn1/tasn_dec.o \
+			 asn1/tasn_enc.o \
+			 asn1/tasn_fre.o \
+			 asn1/tasn_new.o \
+			 asn1/tasn_prn.o \
+			 asn1/tasn_typ.o \
+			 asn1/tasn_utl.o \
+			 asn1/x_algor.o \
+			 asn1/x_attrib.o \
+			 asn1/x_bignum.o \
+			 asn1/x_crl.o \
+			 asn1/x_exten.o \
+			 asn1/x_info.o \
+			 asn1/x_long.o \
+			 asn1/x_name.o \
+			 asn1/x_nx509.o \
+			 asn1/x_pkey.o \
+			 asn1/x_pubkey.o \
+			 asn1/x_req.o \
+			 asn1/x_sig.o \
+			 asn1/x_spki.o \
+			 asn1/x_val.o \
+			 asn1/x_x509.o \
+			 asn1/x_x509a.o \
+			 bf/bf_cfb64.o \
+			 bf/bf_ecb.o \
+			 bf/bf_enc.o \
+			 bf/bf_ofb64.o \
+			 bf/bf_skey.o \
+			 bio/b_dump.o \
+			 bio/b_posix.o \
+			 bio/b_print.o \
+			 bio/b_sock.o \
+			 bio/bf_buff.o \
+			 bio/bf_nbio.o \
+			 bio/bf_null.o \
+			 bio/bio_cb.o \
+			 bio/bio_err.o \
+			 bio/bio_lib.o \
+			 bio/bss_acpt.o \
+			 bio/bss_bio.o \
+			 bio/bss_conn.o \
+			 bio/bss_dgram.o \
+			 bio/bss_fd.o \
+			 bio/bss_file.o \
+			 bio/bss_log.o \
+			 bio/bss_mem.o \
+			 bio/bss_null.o \
+			 bio/bss_sock.o \
+			 bn/bn_add.o \
+			 bn/bn_asm.o \
+			 bn/bn_blind.o \
+			 bn/bn_const.o \
+			 bn/bn_ctx.o \
+			 bn/bn_depr.o \
+			 bn/bn_div.o \
+			 bn/bn_err.o \
+			 bn/bn_exp.o \
+			 bn/bn_exp2.o \
+			 bn/bn_gcd.o \
+			 bn/bn_gf2m.o \
+			 bn/bn_kron.o \
+			 bn/bn_lib.o \
+			 bn/bn_mod.o \
+			 bn/bn_mont.o \
+			 bn/bn_mpi.o \
+			 bn/bn_mul.o \
+			 bn/bn_nist.o \
+			 bn/bn_prime.o \
+			 bn/bn_print.o \
+			 bn/bn_rand.o \
+			 bn/bn_recp.o \
+			 bn/bn_shift.o \
+			 bn/bn_sqr.o \
+			 bn/bn_sqrt.o \
+			 bn/bn_word.o \
+			 bn/bn_x931p.o \
+			 buffer/buf_err.o \
+			 buffer/buf_str.o \
+			 buffer/buffer.o \
+			 camellia/cmll_cfb.o \
+			 camellia/cmll_ctr.o \
+			 camellia/cmll_ecb.o \
+			 camellia/cmll_misc.o \
+			 camellia/cmll_ofb.o \
+			 cast/c_cfb64.o \
+			 cast/c_ecb.o \
+			 cast/c_enc.o \
+			 cast/c_ofb64.o \
+			 cast/c_skey.o \
+			 chacha/chacha.o \
+			 cmac/cm_ameth.o \
+			 cmac/cm_pmeth.o \
+			 cmac/cmac.o \
+			 comp/c_rle.o \
+			 comp/c_zlib.o \
+			 comp/comp_err.o \
+			 comp/comp_lib.o \
+			 conf/conf_api.o \
+			 conf/conf_def.o \
+			 conf/conf_err.o \
+			 conf/conf_lib.o \
+			 conf/conf_mall.o \
+			 conf/conf_mod.o \
+			 conf/conf_sap.o \
+			 des/cbc_cksm.o \
+			 des/cbc_enc.o \
+			 des/cfb64ede.o \
+			 des/cfb64enc.o \
+			 des/cfb_enc.o \
+			 des/des_enc.o \
+			 des/ecb3_enc.o \
+			 des/ecb_enc.o \
+			 des/ede_cbcm_enc.o \
+			 des/enc_read.o \
+			 des/enc_writ.o \
+			 des/fcrypt.o \
+			 des/fcrypt_b.o \
+			 des/ofb64ede.o \
+			 des/ofb64enc.o \
+			 des/ofb_enc.o \
+			 des/pcbc_enc.o \
+			 des/qud_cksm.o \
+			 des/rand_key.o \
+			 des/set_key.o \
+			 des/str2key.o \
+			 des/xcbc_enc.o \
+			 dh/dh_ameth.o \
+			 dh/dh_asn1.o \
+			 dh/dh_check.o \
+			 dh/dh_depr.o \
+			 dh/dh_err.o \
+			 dh/dh_gen.o \
+			 dh/dh_key.o \
+			 dh/dh_lib.o \
+			 dh/dh_pmeth.o \
+			 dh/dh_prn.o \
+			 dsa/dsa_ameth.o \
+			 dsa/dsa_asn1.o \
+			 dsa/dsa_depr.o \
+			 dsa/dsa_err.o \
+			 dsa/dsa_gen.o \
+			 dsa/dsa_key.o \
+			 dsa/dsa_lib.o \
+			 dsa/dsa_ossl.o \
+			 dsa/dsa_pmeth.o \
+			 dsa/dsa_prn.o \
+			 dsa/dsa_sign.o \
+			 dsa/dsa_vrf.o \
+			 ec/ec2_mult.o \
+			 ec/ec2_oct.o \
+			 ec/ec2_smpl.o \
+			 ec/ec_ameth.o \
+			 ec/ec_asn1.o \
+			 ec/ec_check.o \
+			 ec/ec_curve.o \
+			 ec/ec_cvt.o \
+			 ec/ec_err.o \
+			 ec/ec_key.o \
+			 ec/ec_lib.o \
+			 ec/ec_mult.o \
+			 ec/ec_oct.o \
+			 ec/ec_pmeth.o \
+			 ec/ec_print.o \
+			 ec/eck_prn.o \
+			 ec/ecp_mont.o \
+			 ec/ecp_nist.o \
+			 ec/ecp_oct.o \
+			 ec/ecp_smpl.o \
+			 ecdh/ech_err.o \
+			 ecdh/ech_key.o \
+			 ecdh/ech_lib.o \
+			 ecdsa/ecs_asn1.o \
+			 ecdsa/ecs_err.o \
+			 ecdsa/ecs_lib.o \
+			 ecdsa/ecs_ossl.o \
+			 ecdsa/ecs_sign.o \
+			 ecdsa/ecs_vrf.o \
+			 engine/eng_all.o \
+			 engine/eng_cnf.o \
+			 engine/eng_ctrl.o \
+			 engine/eng_dyn.o \
+			 engine/eng_err.o \
+			 engine/eng_fat.o \
+			 engine/eng_init.o \
+			 engine/eng_lib.o \
+			 engine/eng_list.o \
+			 engine/eng_openssl.o \
+			 engine/eng_pkey.o \
+			 engine/eng_table.o \
+			 engine/tb_asnmth.o \
+			 engine/tb_cipher.o \
+			 engine/tb_dh.o \
+			 engine/tb_digest.o \
+			 engine/tb_dsa.o \
+			 engine/tb_ecdh.o \
+			 engine/tb_ecdsa.o \
+			 engine/tb_pkmeth.o \
+			 engine/tb_rand.o \
+			 engine/tb_rsa.o \
+			 engine/tb_store.o \
+			 err/err.o \
+			 err/err_all.o \
+			 err/err_prn.o \
+			 evp/bio_b64.o \
+			 evp/bio_enc.o \
+			 evp/bio_md.o \
+			 evp/c_all.o \
+			 evp/digest.o \
+			 evp/e_aes.o \
+			 evp/e_aes_cbc_hmac_sha1.o \
+			 evp/e_bf.o \
+			 evp/e_camellia.o \
+			 evp/e_cast.o \
+			 evp/e_chacha.o \
+			 evp/e_chacha20poly1305.o \
+			 evp/e_des.o \
+			 evp/e_des3.o \
+			 evp/e_gost2814789.o \
+			 evp/e_idea.o \
+			 evp/e_null.o \
+			 evp/e_old.o \
+			 evp/e_rc2.o \
+			 evp/e_rc4.o \
+			 evp/e_rc4_hmac_md5.o \
+			 evp/e_xcbc_d.o \
+			 evp/encode.o \
+			 evp/evp_aead.o \
+			 evp/evp_enc.o \
+			 evp/evp_err.o \
+			 evp/evp_key.o \
+			 evp/evp_lib.o \
+			 evp/evp_pbe.o \
+			 evp/evp_pkey.o \
+			 evp/m_dss.o \
+			 evp/m_dss1.o \
+			 evp/m_ecdsa.o \
+			 evp/m_gost2814789.o \
+			 evp/m_gostr341194.o \
+			 evp/m_md4.o \
+			 evp/m_md5.o \
+			 evp/m_null.o \
+			 evp/m_ripemd.o \
+			 evp/m_sha1.o \
+			 evp/m_sigver.o \
+			 evp/m_streebog.o \
+			 evp/m_wp.o \
+			 evp/names.o \
+			 evp/p5_crpt.o \
+			 evp/p5_crpt2.o \
+			 evp/p_dec.o \
+			 evp/p_enc.o \
+			 evp/p_lib.o \
+			 evp/p_open.o \
+			 evp/p_seal.o \
+			 evp/p_sign.o \
+			 evp/p_verify.o \
+			 evp/pmeth_fn.o \
+			 evp/pmeth_gn.o \
+			 evp/pmeth_lib.o \
+			 gost/gost2814789.o \
+			 gost/gost89_keywrap.o \
+			 gost/gost89_params.o \
+			 gost/gost89imit_ameth.o \
+			 gost/gost89imit_pmeth.o \
+			 gost/gost_asn1.o \
+			 gost/gost_err.o \
+			 gost/gostr341001.o \
+			 gost/gostr341001_ameth.o \
+			 gost/gostr341001_key.o \
+			 gost/gostr341001_params.o \
+			 gost/gostr341001_pmeth.o \
+			 gost/gostr341194.o \
+			 gost/streebog.o \
+			 hmac/hm_ameth.o \
+			 hmac/hm_pmeth.o \
+			 hmac/hmac.o \
+			 idea/i_cbc.o \
+			 idea/i_cfb64.o \
+			 idea/i_ecb.o \
+			 idea/i_ofb64.o \
+			 idea/i_skey.o \
+			 krb5/krb5_asn.o \
+			 lhash/lh_stats.o \
+			 lhash/lhash.o \
+			 md4/md4_dgst.o \
+			 md4/md4_one.o \
+			 md5/md5_dgst.o \
+			 md5/md5_one.o \
+			 modes/cbc128.o \
+			 modes/ccm128.o \
+			 modes/cfb128.o \
+			 modes/ctr128.o \
+			 modes/cts128.o \
+			 modes/gcm128.o \
+			 modes/ofb128.o \
+			 modes/xts128.o \
+			 objects/o_names.o \
+			 objects/obj_dat.o \
+			 objects/obj_err.o \
+			 objects/obj_lib.o \
+			 objects/obj_xref.o \
+			 ocsp/ocsp_asn.o \
+			 ocsp/ocsp_cl.o \
+			 ocsp/ocsp_err.o \
+			 ocsp/ocsp_ext.o \
+			 ocsp/ocsp_ht.o \
+			 ocsp/ocsp_lib.o \
+			 ocsp/ocsp_prn.o \
+			 ocsp/ocsp_srv.o \
+			 ocsp/ocsp_vfy.o \
+			 pem/pem_all.o \
+			 pem/pem_err.o \
+			 pem/pem_info.o \
+			 pem/pem_lib.o \
+			 pem/pem_oth.o \
+			 pem/pem_pk8.o \
+			 pem/pem_pkey.o \
+			 pem/pem_seal.o \
+			 pem/pem_sign.o \
+			 pem/pem_x509.o \
+			 pem/pem_xaux.o \
+			 pem/pvkfmt.o \
+			 pkcs12/p12_add.o \
+			 pkcs12/p12_asn.o \
+			 pkcs12/p12_attr.o \
+			 pkcs12/p12_crpt.o \
+			 pkcs12/p12_crt.o \
+			 pkcs12/p12_decr.o \
+			 pkcs12/p12_init.o \
+			 pkcs12/p12_key.o \
+			 pkcs12/p12_kiss.o \
+			 pkcs12/p12_mutl.o \
+			 pkcs12/p12_npas.o \
+			 pkcs12/p12_p8d.o \
+			 pkcs12/p12_p8e.o \
+			 pkcs12/p12_utl.o \
+			 pkcs12/pk12err.o \
+			 pkcs7/bio_pk7.o \
+			 pkcs7/pk7_asn1.o \
+			 pkcs7/pk7_attr.o \
+			 pkcs7/pk7_doit.o \
+			 pkcs7/pk7_lib.o \
+			 pkcs7/pk7_mime.o \
+			 pkcs7/pk7_smime.o \
+			 pkcs7/pkcs7err.o \
+			 poly1305/poly1305.o \
+			 rand/rand_err.o \
+			 rand/rand_lib.o \
+			 rand/randfile.o \
+			 rc2/rc2_cbc.o \
+			 rc2/rc2_ecb.o \
+			 rc2/rc2_skey.o \
+			 rc2/rc2cfb64.o \
+			 rc2/rc2ofb64.o \
+			 ripemd/rmd_dgst.o \
+			 ripemd/rmd_one.o \
+			 rsa/rsa_ameth.o \
+			 rsa/rsa_asn1.o \
+			 rsa/rsa_chk.o \
+			 rsa/rsa_crpt.o \
+			 rsa/rsa_depr.o \
+			 rsa/rsa_eay.o \
+			 rsa/rsa_err.o \
+			 rsa/rsa_gen.o \
+			 rsa/rsa_lib.o \
+			 rsa/rsa_none.o \
+			 rsa/rsa_oaep.o \
+			 rsa/rsa_pk1.o \
+			 rsa/rsa_pmeth.o \
+			 rsa/rsa_prn.o \
+			 rsa/rsa_pss.o \
+			 rsa/rsa_saos.o \
+			 rsa/rsa_sign.o \
+			 rsa/rsa_ssl.o \
+			 rsa/rsa_x931.o \
+			 sha/sha1_one.o \
+			 sha/sha1dgst.o \
+			 sha/sha256.o \
+			 sha/sha512.o \
+			 stack/stack.o \
+			 ts/ts_asn1.o \
+			 ts/ts_conf.o \
+			 ts/ts_err.o \
+			 ts/ts_lib.o \
+			 ts/ts_req_print.o \
+			 ts/ts_req_utils.o \
+			 ts/ts_rsp_print.o \
+			 ts/ts_rsp_sign.o \
+			 ts/ts_rsp_utils.o \
+			 ts/ts_rsp_verify.o \
+			 ts/ts_verify_ctx.o \
+			 txt_db/txt_db.o \
+			 whrlpool/wp_dgst.o \
+			 x509/by_dir.o \
+			 x509/by_file.o \
+			 x509/by_mem.o \
+			 x509/x509_att.o \
+			 x509/x509_cmp.o \
+			 x509/x509_d2.o \
+			 x509/x509_def.o \
+			 x509/x509_err.o \
+			 x509/x509_ext.o \
+			 x509/x509_lu.o \
+			 x509/x509_obj.o \
+			 x509/x509_r2x.o \
+			 x509/x509_req.o \
+			 x509/x509_set.o \
+			 x509/x509_trs.o \
+			 x509/x509_txt.o \
+			 x509/x509_v3.o \
+			 x509/x509_vfy.o \
+			 x509/x509_vpm.o \
+			 x509/x509cset.o \
+			 x509/x509name.o \
+			 x509/x509rset.o \
+			 x509/x509spki.o \
+			 x509/x509type.o \
+			 x509/x_all.o \
+			 x509v3/pcy_cache.o \
+			 x509v3/pcy_data.o \
+			 x509v3/pcy_lib.o \
+			 x509v3/pcy_map.o \
+			 x509v3/pcy_node.o \
+			 x509v3/pcy_tree.o \
+			 x509v3/v3_akey.o \
+			 x509v3/v3_akeya.o \
+			 x509v3/v3_alt.o \
+			 x509v3/v3_bcons.o \
+			 x509v3/v3_bitst.o \
+			 x509v3/v3_conf.o \
+			 x509v3/v3_cpols.o \
+			 x509v3/v3_crld.o \
+			 x509v3/v3_enum.o \
+			 x509v3/v3_extku.o \
+			 x509v3/v3_genn.o \
+			 x509v3/v3_ia5.o \
+			 x509v3/v3_info.o \
+			 x509v3/v3_int.o \
+			 x509v3/v3_lib.o \
+			 x509v3/v3_ncons.o \
+			 x509v3/v3_ocsp.o \
+			 x509v3/v3_pci.o \
+			 x509v3/v3_pcia.o \
+			 x509v3/v3_pcons.o \
+			 x509v3/v3_pku.o \
+			 x509v3/v3_pmaps.o \
+			 x509v3/v3_prn.o \
+			 x509v3/v3_purp.o \
+			 x509v3/v3_skey.o \
+			 x509v3/v3_sxnet.o \
+			 x509v3/v3_utl.o \
+			 x509v3/v3err.o \
+			 ui/ui_err.o \
+			 ui/ui_lib.o \
+			 ui/ui_openssl.o \
+			 ui/ui_util.o \
+			 dso/dso_dlfcn.o \
+			 dso/dso_err.o \
+			 dso/dso_lib.o \
+			 dso/dso_null.o \
+			 dso/dso_openssl.o
+
+LIBSSL_CFILES = \
+					 $(top_srcdir)/ssl/bio_ssl.o \
+					 $(top_srcdir)/ssl/bs_ber.o \
+					 $(top_srcdir)/ssl/bs_cbb.o \
+					 $(top_srcdir)/ssl/bs_cbs.o \
+					 $(top_srcdir)/ssl/d1_both.o \
+					 $(top_srcdir)/ssl/d1_clnt.o \
+					 $(top_srcdir)/ssl/d1_enc.o \
+					 $(top_srcdir)/ssl/d1_lib.o \
+					 $(top_srcdir)/ssl/d1_meth.o \
+					 $(top_srcdir)/ssl/d1_pkt.o \
+					 $(top_srcdir)/ssl/d1_srtp.o \
+					 $(top_srcdir)/ssl/d1_srvr.o \
+					 $(top_srcdir)/ssl/pqueue.o \
+					 $(top_srcdir)/ssl/s23_clnt.o \
+					 $(top_srcdir)/ssl/s23_lib.o \
+					 $(top_srcdir)/ssl/s23_pkt.o \
+					 $(top_srcdir)/ssl/s23_srvr.o \
+					 $(top_srcdir)/ssl/s3_both.o \
+					 $(top_srcdir)/ssl/s3_cbc.o \
+					 $(top_srcdir)/ssl/s3_clnt.o \
+					 $(top_srcdir)/ssl/s3_lib.o \
+					 $(top_srcdir)/ssl/s3_pkt.o \
+					 $(top_srcdir)/ssl/s3_srvr.o \
+					 $(top_srcdir)/ssl/ssl_algs.o \
+					 $(top_srcdir)/ssl/ssl_asn1.o \
+					 $(top_srcdir)/ssl/ssl_cert.o \
+					 $(top_srcdir)/ssl/ssl_ciph.o \
+					 $(top_srcdir)/ssl/ssl_err.o \
+					 $(top_srcdir)/ssl/ssl_err2.o \
+					 $(top_srcdir)/ssl/ssl_lib.o \
+					 $(top_srcdir)/ssl/ssl_rsa.o \
+					 $(top_srcdir)/ssl/ssl_sess.o \
+					 $(top_srcdir)/ssl/ssl_stat.o \
+					 $(top_srcdir)/ssl/ssl_txt.o \
+					 $(top_srcdir)/ssl/t1_clnt.o \
+					 $(top_srcdir)/ssl/t1_enc.o \
+					 $(top_srcdir)/ssl/t1_lib.o \
+					 $(top_srcdir)/ssl/t1_meth.o \
+					 $(top_srcdir)/ssl/t1_reneg.o \
+					 $(top_srcdir)/ssl/t1_srvr.o
+
+COMPAT_FILES = compat/strlcat.o \
+					compat/strlcpy.o \
+					compat/reallocarray.o \
+					compat/timingsafe_memcmp.o \
+					compat/timingsafe_bcmp.o \
+					compat/arc4random.o \
+					compat/explicit_bzero.o \
+					compat/getentropy_linux.o
+
+# Add files here for your TLS processing module
+TLSPROCESSINGMODULE = logpoint.o
+
+%.o: %.s
+	@$(CC) $(CCASFLAGS) -c $< -fPIC -DPIC -o $@
+
+%.o: %.S
+	$(eval srcbasefile=$(basename $@))
+	$(eval dstbasefile=$(basename $(notdir $@)))
+	@$(eval maindir=$(dir $@))
+	@$(CC) $(DEFS) $(CPPFLAGS) $(INCLUDE) $(CCASFLAGS) $(Enclave_C_Flags) -I$(SGX_SDK)/include -fPIC -DPIC -c -o $(maindir)$(dstbasefile).o $(srcbasefile).S
+
+%.o: %.c
+	$(eval srcbasefile=$(basename $@))
+	$(eval dstbasefile=$(basename $(notdir $@)))
+	$(eval maindir=$(dir $@))
+	@$(CC) $(DEFS) $(INCLUDE) $(CPPFLAGS) $(CFLAGS) -I$(SGX_SDK)/include -E -o $(maindir)$(dstbasefile).i $(srcbasefile).c
+	@$(CC) $(DEFS) $(INCLUDE) $(CPPFLAGS) $(CFLAGS) $(Enclave_C_Flags) -I$(SGX_SDK)/include -fPIC -DPIC -c -o $(maindir)$(dstbasefile).o $(maindir)$(dstbasefile).i
+
+sfiles: $(SFILES)
+
+libcrypto_sfiles: $(LIBCRYPTO_SFILES)
+
+libcrypto_cfiles: $(LIBCRYPTO_CFILES)
+
+libssl_cfiles: $(LIBSSL_CFILES)
+
+compat: $(COMPAT_FILES)
+
+tlsprocessingmodule_cfiles: $(TLSPROCESSINGMODULE)
+
+#################################
+
+enclaveshim_ocalls.o: enclaveshim_ocalls.c enclave_t.c enclaveshim_ocalls.h
+	$(eval srcbasefile=$(basename $@))
+	@$(CC) $(CFLAGS) -I../include -I$(SGX_SDK)/include -E -o $(srcbasefile).i $<
+	@$(CC) $(CFLAGS) -I../include $(Enclave_C_Flags) -I$(SGX_SDK)/include -fPIC -DPIC -c -o $@ $(srcbasefile).i
+	@echo "CC  <=  $<"
+
+tls_processing_interface.o: tls_processing_interface.c tls_processing_interface.h
+	$(eval srcbasefile=$(basename $@))
+	@$(CC) $(CFLAGS) -DCOMPILE_WITH_INTEL_SGX -I../include -I$(SGX_SDK)/include -I. -Iauditing/include -E -o $(srcbasefile).i $<
+	@$(CC) $(CFLAGS) $(Enclave_C_Flags) -I$(SGX_SDK)/include -fPIC -DPIC -c -o $@ $(srcbasefile).i
+	@echo "CC  <=  $<"
+
+ecall_queue.o: ecall_queue.c enclave_t.c
+	$(eval srcbasefile=$(basename $@))
+	@$(CC) $(CFLAGS) -DCOMPILE_WITH_INTEL_SGX -I$(SGX_SDK)/include -E -o $(srcbasefile).i $<
+	@$(CC) $(CFLAGS) $(Enclave_C_Flags) -I$(SGX_SDK)/include -fPIC -DPIC -c -o $@ $(srcbasefile).i
+	@echo "CC  <=  $<"
+
+mpmc_queue.o: mpmc_queue.c enclave_t.c
+	$(eval srcbasefile=$(basename $@))
+	@$(CC) $(CFLAGS) -DCOMPILE_WITH_INTEL_SGX -I$(SGX_SDK)/include -E -o $(srcbasefile).i $<
+	@$(CC) $(CFLAGS) $(Enclave_C_Flags) -I$(SGX_SDK)/include -fPIC -DPIC -c -o $@ $(srcbasefile).i
+	@echo "CC  <=  $<"
+
+lthread.o: lthread.c enclave_t.c
+	$(eval srcbasefile=$(basename $@))
+	@$(CC) $(CFLAGS) -I../include -I$(SGX_SDK)/include -E -o $(srcbasefile).i $<
+	@$(CC) $(CFLAGS) -fPIC $(Enclave_C_Flags) -I$(SGX_SDK)/include -c -o $@ $(srcbasefile).i
+	@echo "CC  <=  $<"
+
+lthread_sched.o: lthread_sched.c enclave_t.c
+	$(eval srcbasefile=$(basename $@))
+	@$(CC) $(CFLAGS) -I../include -I$(SGX_SDK)/include -E -o $(srcbasefile).i $<
+	@$(CC) $(CFLAGS) -fPIC $(Enclave_C_Flags) -I$(SGX_SDK)/include -c -o $@ $(srcbasefile).i
+	@echo "CC  <=  $<"
+
+mempool.o: mempool.c enclave_t.c
+	$(eval srcbasefile=$(basename $@))
+	@$(CC) $(CFLAGS) -I../include -I$(SGX_SDK)/include -E -o $(srcbasefile).i $<
+	@$(CC) $(CFLAGS) -fPIC $(Enclave_C_Flags) -I$(SGX_SDK)/include -c -o $@ $(srcbasefile).i
+	@echo "CC  <=  $<"
+
+enclave: enclave_t.o enclaveshim_ocalls.o tls_processing_interface.o ecall_queue.o mpmc_queue.o lthread.o lthread_sched.o mempool.o sfiles libcrypto_sfiles libcrypto_cfiles libssl_cfiles compat tlsprocessingmodule_cfiles
+	@$(CC) enclave_t.o enclaveshim_ocalls.o tls_processing_interface.o ecall_queue.o mpmc_queue.o lthread.o lthread_sched.o mempool.o $(SFILES) $(LIBCRYPTO_SFILES) $(LIBCRYPTO_CFILES) $(LIBSSL_CFILES) $(COMPAT_FILES) $(TLSPROCESSINGMODULE) -o $(Enclave_Name) $(Enclave_Link_Flags)
+	@echo "LINK =>  $(Enclave_Name)"
+
+signed_enclave: enclave
+	@$(SGX_ENCLAVE_SIGNER) sign -ignore-init-sec-error -key enclave_private.pem -enclave $(Enclave_Name) -out $(Signed_Enclave_Name) -config $(Enclave_Config_File)
+	@echo "SIGN =>  $(Signed_Enclave_Name)"
+	@rm $(Enclave_Name)
+
+#################################
+
+link: enclave_u.o hashmap-nosgx.o ecall_queue-nosgx.o enclaveshim_ecalls.o ocalls.o cpuid-elf-x86_64-ocall.o
+	ar cru libenclave.a enclave_u.o hashmap-nosgx.o ecall_queue-nosgx.o enclaveshim_ecalls.o ocalls.o cpuid-elf-x86_64-ocall.o
+	$(CC) -fPIC -shared -o libenclave.so enclave_u.o hashmap-nosgx.o ecall_queue-nosgx.o enclaveshim_ecalls.o ocalls.o cpuid-elf-x86_64-ocall.o -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name)
+
+install: link
+	-mkdir -p ../lib
+	-ln -sfn ../crypto/libenclave.so ../lib/libssl.so
+	-ln -sfn ../crypto/libenclave.so ../lib/libcrypto.so
+	-ln -sfn ../crypto/libenclave.a ../lib/libssl.a
+	-ln -sfn ../crypto/libenclave.a ../lib/libcrypto.a
+
+clean:
+	rm -rf \.libs
+	rm -rf *\.la
+	find . -iname "enclave_u.?" -delete
+	find . -iname "enclave_t.?" -delete
+	find . -iname "$(Enclave_Name)" -delete
+	find . -iname "$(Signed_Enclave_Name)" -delete
+	find . -iname "*\.dirstamp" -delete
+	find . -iname "*\.o" -delete
+	find $(top_srcdir)/ssl -iname "*\.o" -delete
+	find . -iname "*\.i" -delete
+	find $(top_srcdir)/ssl -iname "*\.i" -delete
+	find . -iname "*\.deps" -delete
+	find . -iname "*\.libs" -delete
+	find . -iname "libenclave.a" -delete
+	find . -iname "libenclave.so" -delete
+

--- a/src/talos/patch_libressl.sh
+++ b/src/talos/patch_libressl.sh
@@ -8,3 +8,4 @@ cp enclaveshim/* ${LIBRESSL}/crypto/
 # patch the libressl files
 cd $LIBRESSL
 find ../talos/patch -mindepth 1 -maxdepth 1 -type f -name "*.patch" -print0 | xargs -0 -I {} patch -p0 -i {} 
+find . | grep .c$ | xargs grep "explicit_bzero" -r -l | xargs sed -i -e 's/explicit_bzero/bzero/g'


### PR DESCRIPTION
This fixes the problems discussed int #21 .

1. Replace calls to `explicit_bzero` with calls to `bzero` (this is a hack, there may be a better way)
2. Replace `libsgx_tstdcxx` with `libsgx_tcxx`
3. Add -ignore-init-sec-error (hack, not sure how to go around this)

Note that this doesn't make it compile (due to -Wall and -Werror, but only due to that: removing these flags fixes compilation fully)