### PR TITLE
Use Intel SDK 2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ENV	LIBRESSL_VERSION 2.4.1
 
 ARG 	MAIN_DIR=/talos/
 
-ARG	SGX_FILE=sgx_linux_ubuntu16.04.1_x64_sdk_1.9.100.39124.bin
-ARG	SGX_URL=https://download.01.org/intel-sgx/linux-1.9/${SGX_FILE}
+ARG	SGX_FILE=sgx_linux_x64_sdk_2.3.100.46354.bin
+ARG	SGX_URL=https://download.01.org/intel-sgx/linux-2.3/ubuntu16.04-desktop/${SGX_FILE}
 
 ARG	LIBRESSL_ROOT=${MAIN_DIR}/src/libressl-${LIBRESSL_VERSION}/
 ARG	LIBRESSL_CRYPTO=${LIBRESSL_ROOT}/crypto


### PR DESCRIPTION
TaLoS/src/talos/enclaveshim/Makefile.sgx uses "-ignore-init-sec-error" which was added to the Intel sdk in version 2.1.3.:
https://github.com/intel/linux-sgx/blob/75dd558bdaff030688d483e1a2bd51d38c55ab49/sdk/sign_tool/SignTool/util_st.h

Currently 'docker build -t talos .' fails because of '-ignore-init-sec-error' not being available in the installed sdk.